### PR TITLE
Fix empty results issue on Windows

### DIFF
--- a/apiritif/loadgen.py
+++ b/apiritif/loadgen.py
@@ -49,6 +49,10 @@ def spawn_worker(params):
 
     :type params: Params
     """
+    setup_logging()
+    log.info("Adding worker: idx=%s\tconcurrency=%s\tresults=%s", params.worker_index, params.concurrency,
+             params.report)
+
     worker = Worker(params)
     worker.start()
     worker.join()
@@ -118,9 +122,6 @@ class Supervisor(Thread):
         workers = multiprocessing.Pool(processes=self.params.worker_count)
         args = list(self._concurrency_slicer())
 
-        for item in args:
-            log.info("Adding worker: idx=%s\tconcurrency=%s\tresults=%s", item.worker_index, item.concurrency,
-                     item.report)
         workers.map(spawn_worker, args)
         workers.close()
         workers.join()
@@ -472,10 +473,14 @@ def cmdline_to_params():
     return params
 
 
-if __name__ == '__main__':
+def setup_logging():
     logging.basicConfig(level=logging.INFO, stream=sys.stdout,
                         format="%(asctime)s:%(levelname)s:%(process)s:%(thread)s:%(name)s:%(message)s")
     apiritif.http.log.setLevel(logging.WARNING)
+
+
+if __name__ == '__main__':
+    setup_logging()
     supervisor = Supervisor(cmdline_to_params())
     supervisor.start()
     supervisor.join()

--- a/apiritif/loadgen.py
+++ b/apiritif/loadgen.py
@@ -49,9 +49,6 @@ def spawn_worker(params):
 
     :type params: Params
     """
-    log.info("Adding worker: idx=%s\tconcurrency=%s\tresults=%s", params.worker_index, params.concurrency,
-             params.report)
-
     worker = Worker(params)
     worker.start()
     worker.join()
@@ -120,6 +117,10 @@ class Supervisor(Thread):
 
         workers = multiprocessing.Pool(processes=self.params.worker_count)
         args = list(self._concurrency_slicer())
+
+        for item in args:
+            log.info("Adding worker: idx=%s\tconcurrency=%s\tresults=%s", item.worker_index, item.concurrency,
+                     item.report)
         workers.map(spawn_worker, args)
         workers.close()
         workers.join()


### PR DESCRIPTION
It is caused by apiritif's log object being non-sharable on Python3 + Windows.

The issue is that when `spawn_worker` executes in worker processes and is unable to use logger shared by parent process. 

Proposed solution is to move the "Adding worker" announcement into main process, which owns the log object.