### PR TITLE
Fix endlines on Windows

### DIFF
--- a/apiritif/loadgen.py
+++ b/apiritif/loadgen.py
@@ -35,7 +35,6 @@ from nose.plugins.manager import DefaultPluginManager
 
 import apiritif
 from apiritif.samples import ApiritifSampleExtractor, Sample
-from apiritif.utils import is_windows
 
 log = logging.getLogger("loadgen")
 
@@ -274,8 +273,8 @@ class JTLSampleWriter(LDJSONSampleWriter):
 
         fieldnames = ["timeStamp", "elapsed", "Latency", "label", "responseCode", "responseMessage", "success",
                       "allThreads", "bytes"]
-        endline = '\r\n' if is_windows() else '\n'
-        self.writer = csv.DictWriter(self.out_stream, fieldnames=fieldnames, dialect=csv.excel, endline=endline)
+        self.writer = csv.DictWriter(self.out_stream, fieldnames=fieldnames, dialect=csv.excel,
+                                     lineterminator=os.linesep)
         self.writer.writeheader()
         self.out_stream.flush()
 

--- a/apiritif/loadgen.py
+++ b/apiritif/loadgen.py
@@ -35,6 +35,7 @@ from nose.plugins.manager import DefaultPluginManager
 
 import apiritif
 from apiritif.samples import ApiritifSampleExtractor, Sample
+from apiritif.utils import is_windows
 
 log = logging.getLogger("loadgen")
 
@@ -273,7 +274,8 @@ class JTLSampleWriter(LDJSONSampleWriter):
 
         fieldnames = ["timeStamp", "elapsed", "Latency", "label", "responseCode", "responseMessage", "success",
                       "allThreads", "bytes"]
-        self.writer = csv.DictWriter(self.out_stream, fieldnames=fieldnames, dialect=csv.excel)
+        endline = '\r\n' if is_windows() else '\n'
+        self.writer = csv.DictWriter(self.out_stream, fieldnames=fieldnames, dialect=csv.excel, endline=endline)
         self.writer.writeheader()
         self.out_stream.flush()
 

--- a/apiritif/loadgen.py
+++ b/apiritif/loadgen.py
@@ -257,7 +257,7 @@ class LDJSONSampleWriter(object):
                 self._write_sample(sample, test_count, success_count)
 
     def _write_sample(self, sample, test_count, success_count):
-        self.out_stream.write("%s\n" % json.dumps(sample.to_dict()))
+        self.out_stream.write(json.dumps(sample.to_dict()) + "\n")
         self.out_stream.flush()
 
         report_pattern = "%s,Total:%d Passed:%d Failed:%d\n"
@@ -275,8 +275,8 @@ class JTLSampleWriter(LDJSONSampleWriter):
 
         fieldnames = ["timeStamp", "elapsed", "Latency", "label", "responseCode", "responseMessage", "success",
                       "allThreads", "bytes"]
-        self.writer = csv.DictWriter(self.out_stream, fieldnames=fieldnames, dialect=csv.excel,
-                                     lineterminator=os.linesep)
+        endline = '\n'  # \r will be preprended automatically because out_stream is opened in text mode
+        self.writer = csv.DictWriter(self.out_stream, fieldnames=fieldnames, dialect=csv.excel, lineterminator=endline)
         self.writer.writeheader()
         self.out_stream.flush()
 

--- a/apiritif/utils.py
+++ b/apiritif/utils.py
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
+import platform
 import re
 
 
@@ -44,3 +45,7 @@ def assert_not_regexp(regex, text, match=False, msg=None):
         if re.findall(regex, text):
             msg = msg or "Regex %r unexpectedly found something in text %r" % (regex, shorten(text, 100))
             raise AssertionError(msg)
+
+
+def is_windows():
+    return platform.system() == 'Windows'

--- a/apiritif/utils.py
+++ b/apiritif/utils.py
@@ -45,7 +45,3 @@ def assert_not_regexp(regex, text, match=False, msg=None):
         if re.findall(regex, text):
             msg = msg or "Regex %r unexpectedly found something in text %r" % (regex, shorten(text, 100))
             raise AssertionError(msg)
-
-
-def is_windows():
-    return platform.system() == 'Windows'


### PR DESCRIPTION
Because CSV writer uses `\r\n` endlines by default and report file was always opened in text mode — we got `\r\r\n` at the end of each line in the report file. This pull request fixes that, so we have `\n` on Unix and `\r\n` on Windows.