### PR TITLE
Allow passing session to target and fix cookies loss

### DIFF
--- a/apiritif/http.py
+++ b/apiritif/http.py
@@ -67,7 +67,7 @@ class http(object):
             session = requests.Session()
         request = requests.Request(method, address,
                                    params=params, headers=headers, cookies=cookies, json=json, data=data)
-        prepared = request.prepare()
+        prepared = session.prepare_request(request)
         try:
             response = session.send(prepared, allow_redirects=allow_redirects, timeout=timeout)
         except requests.exceptions.Timeout:
@@ -341,7 +341,8 @@ class HTTPTarget(object):
                  keep_alive=True,
                  auto_assert_ok=True,
                  timeout=30,
-                 allow_redirects=True):
+                 allow_redirects=True,
+                 session=None):
         self.address = address
         # config flags
         self._base_path = base_path
@@ -352,7 +353,7 @@ class HTTPTarget(object):
         self._timeout = timeout
         self._allow_redirects = allow_redirects
         # internal vars
-        self.__session = None
+        self.__session = session
 
     def use_cookies(self, use=True):
         self._use_cookies = use

--- a/apiritif/http.py
+++ b/apiritif/http.py
@@ -416,7 +416,7 @@ class HTTPTarget(object):
         req_headers.update(headers)
 
         response = http.request(method, address, session=self.__session,
-                                params=params, headers=headers, cookies=cookies, data=data, json=json,
+                                params=params, headers=req_headers, cookies=cookies, data=data, json=json,
                                 allow_redirects=allow_redirects, timeout=timeout)
         if self._auto_assert_ok:
             response.assert_ok()

--- a/apiritif/http.py
+++ b/apiritif/http.py
@@ -68,8 +68,9 @@ class http(object):
         request = requests.Request(method, address,
                                    params=params, headers=headers, cookies=cookies, json=json, data=data)
         prepared = session.prepare_request(request)
+        settings = session.merge_environment_settings(prepared.url, {}, False, False, None)
         try:
-            response = session.send(prepared, allow_redirects=allow_redirects, timeout=timeout)
+            response = session.send(prepared, allow_redirects=allow_redirects, timeout=timeout, **settings)
         except requests.exceptions.Timeout:
             raise TimeoutError("Connection to %s timed out" % address)
         except requests.exceptions.ConnectionError:
@@ -298,7 +299,7 @@ class _EventRecorder(object):
     def record_transaction_start(self, tran):
         self.record_event(TransactionStarted(tran))
         if isinstance(tran, transaction_logged):
-            self.log.info(u"Transaction started:: start_time=%.3f,name=%s", tran.start_time(),tran.name)
+            self.log.info(u"Transaction started:: start_time=%.3f,name=%s", tran.start_time(), tran.name)
 
     def record_transaction_end(self, tran):
         self.record_event(TransactionEnded(tran))


### PR DESCRIPTION
1. Allowing to pass external Session object to HTTPTarget enables case of multiple hosts sharing cookies (eg my.host.com and pay.host.com using wildcard cookie)
2. Fixing `prepare_request` according to https://requests.kennethreitz.org/en/master/user/advanced/#prepared-requests , since it is just broken for now
3. Fixing HTTP_PROXY env variable handling, according to https://github.com/psf/requests/issues/3190
4. Fix target's request headers not used in request