### PR TITLE
Fix one more problematic cookie access place

### DIFF
--- a/apiritif/http.py
+++ b/apiritif/http.py
@@ -302,7 +302,7 @@ class RequestFailure(Request):
         self.method = method
         self.address = address
         self.request = request
-        self.exception = str(exc)
+        self.exception = exc
         self.session = session
 
     def __repr__(self):

--- a/apiritif/http.py
+++ b/apiritif/http.py
@@ -24,6 +24,7 @@ from io import BytesIO
 import jsonpath_rw
 import requests
 from lxml import etree
+from requests.structures import CaseInsensitiveDict
 
 import apiritif
 from apiritif.thread import get_from_thread_store, put_into_thread_store
@@ -550,7 +551,7 @@ class HTTPResponse(object):
         self.status_code = int(py_response.status_code)
         self.reason = py_response.reason
 
-        self.headers = dict(py_response.headers)
+        self.headers = CaseInsensitiveDict(py_response.headers)
         self.cookies = {x: py_response.cookies.get(x) for x in py_response.cookies}
 
         self.text = py_response.text

--- a/apiritif/http.py
+++ b/apiritif/http.py
@@ -48,7 +48,8 @@ class http(object):
 
     @staticmethod
     def request(method, address, session=None,
-                params=None, headers=None, cookies=None, data=None, json=None, allow_redirects=True, timeout=30):
+                params=None, headers=None, cookies=None, data=None, json=None, files=None,
+                allow_redirects=True, timeout=30):
         """
 
         :param method: str
@@ -57,8 +58,8 @@ class http(object):
         :rtype: HTTPResponse
         """
         http.log.info("Request: %s %s", method, address)
-        msg = "Request: params=%r, headers=%r, cookies=%r, data=%r, json=%r, allow_redirects=%r, timeout=%r"
-        http.log.debug(msg, params, headers, cookies, data, json, allow_redirects, timeout)
+        msg = "Request: params=%r, headers=%r, cookies=%r, data=%r, json=%r, files=%r, allow_redirects=%r, timeout=%r"
+        http.log.debug(msg, params, headers, cookies, data, json, files, allow_redirects, timeout)
 
         if headers is None:
             headers = {}
@@ -68,7 +69,7 @@ class http(object):
         if session is None:
             session = requests.Session()
         request = requests.Request(method, address,
-                                   params=params, headers=headers, cookies=cookies, json=json, data=data)
+                                   params=params, headers=headers, cookies=cookies, json=json, data=data, files=files)
         prepared = session.prepare_request(request)
         settings = session.merge_environment_settings(prepared.url, {}, False, False, None)
         try:
@@ -447,7 +448,8 @@ class HTTPTarget(object):
         return addr
 
     def request(self, method, path,
-                params=None, headers=None, cookies=None, data=None, json=None, allow_redirects=None, timeout=None):
+                params=None, headers=None, cookies=None, data=None, json=None, files=None,
+                allow_redirects=None, timeout=None):
         """
         Prepares and sends an HTTP request. Returns the HTTPResponse object.
 
@@ -471,7 +473,7 @@ class HTTPTarget(object):
         req_headers.update(headers)
 
         response = http.request(method, address, session=self.__session,
-                                params=params, headers=req_headers, cookies=cookies, data=data, json=json,
+                                params=params, headers=req_headers, cookies=cookies, data=data, json=json, files=files,
                                 allow_redirects=allow_redirects, timeout=timeout)
         if self._auto_assert_ok:
             response.assert_ok()

--- a/apiritif/http.py
+++ b/apiritif/http.py
@@ -516,7 +516,7 @@ class HTTPResponse(object):
         self.reason = py_response.reason
 
         self.headers = dict(py_response.headers)
-        self.cookies = dict(py_response.cookies)
+        self.cookies = dict({x: py_response.cookies.get(x) for x in py_response.cookies})
 
         self.text = py_response.text
         self.content = py_response.content

--- a/apiritif/http.py
+++ b/apiritif/http.py
@@ -516,7 +516,7 @@ class HTTPResponse(object):
         self.reason = py_response.reason
 
         self.headers = dict(py_response.headers)
-        self.cookies = dict({x: py_response.cookies.get(x) for x in py_response.cookies})
+        self.cookies = {x: py_response.cookies.get(x) for x in py_response.cookies}
 
         self.text = py_response.text
         self.content = py_response.content

--- a/apiritif/pytest_plugin.py
+++ b/apiritif/pytest_plugin.py
@@ -68,7 +68,7 @@ class ApiritifPytestPlugin(object):
         for item in items:
             self._filter(item['subsamples'])
             if self._detail_level >= 4:
-                if isinstance(item['extras']['requestBody'], bytes):
+                if isinstance(item['extras'].get('requestBody'), bytes):
                     item['extras']['requestBody'] = item['extras']['requestBody'].decode('utf-8')
 
             if self._detail_level <= 3:

--- a/apiritif/pytest_plugin.py
+++ b/apiritif/pytest_plugin.py
@@ -52,9 +52,9 @@ class ApiritifPytestPlugin(object):
         sample = Sample()
         extr = ApiritifSampleExtractor()
         trace = extr.parse_recording(recording, sample)
-        subsamples = trace[0].to_dict()['subsamples']
-        self._filter(subsamples)
-        return subsamples
+        toplevel_sample = trace[0].to_dict()
+        self._filter([toplevel_sample])
+        return toplevel_sample
 
     @pytest.hookimpl(tryfirst=True)
     def pytest_sessionfinish(self, session):
@@ -67,11 +67,11 @@ class ApiritifPytestPlugin(object):
     def _filter(self, items):
         for item in items:
             self._filter(item['subsamples'])
-            if self._detail_level >= 3:
+            if self._detail_level >= 4:
                 if isinstance(item['extras']['requestBody'], bytes):
                     item['extras']['requestBody'] = item['extras']['requestBody'].decode('utf-8')
 
-            if self._detail_level <= 2:
+            if self._detail_level <= 3:
                 item['extras'].pop('requestCookiesRaw', None)
                 item['extras'].pop('requestCookies', None)
                 item['extras'].pop('requestBody', None)
@@ -79,7 +79,7 @@ class ApiritifPytestPlugin(object):
                 item['extras'].pop('requestHeaders', None)
                 item['extras'].pop('responseHeaders', None)
 
-            if self._detail_level <= 1:
+            if self._detail_level <= 2:
                 item.pop('extras', None)
                 item.pop('subsamples', None)
                 item.pop('assertions', None)

--- a/tests/resources/test_single_transaction.py
+++ b/tests/resources/test_single_transaction.py
@@ -12,11 +12,11 @@ class TestAPIRequests(unittest.TestCase):
 
     def test_requests(self):
         with apiritif.transaction('blazedemo 123'):
-            response = apiritif.http.get('http://demo.blazemeter.com/echo.php?echo=123', allow_redirects=True)
-            response.assert_jsonpath('$.GET.echo', expected_value='123')
+            response = apiritif.http.get('https://api.demoblaze.com/entries', allow_redirects=True)
+            response.assert_jsonpath('$.LastEvaluatedKey.id', expected_value='9')
         time.sleep(0.75)
 
         with apiritif.transaction('blazedemo 456'):
-            response = apiritif.http.get('http://demo.blazemeter.com/echo.php?echo=456', allow_redirects=True)
-            response.assert_jsonpath("$['GET']['echo']", expected_value='456789')
+            response = apiritif.http.get('https://api.demoblaze.com/entries', allow_redirects=True)
+            response.assert_jsonpath("$['LastEvaluatedKey']['id']", expected_value='9')
         time.sleep(0.75)

--- a/tests/resources/test_transactions.py
+++ b/tests/resources/test_transactions.py
@@ -27,3 +27,6 @@ class TestTransactions(TestCase):
 
     def test_6_apiritif_assertions_failed(self):
         apiritif.http.get("http://blazedemo.com/").assert_failed()  # this assertion intentionally fails
+
+    def test_7_failed_request(self):
+        apiritif.http.get("http://notexists")

--- a/tests/test_assertions.py
+++ b/tests/test_assertions.py
@@ -80,7 +80,7 @@ class TestRequests(unittest.TestCase):
 
     def test_assert_in_headers(self):
         response = http.get('http://blazedemo.com/')
-        response.assert_in_headers("Content-Type: text/html")
+        response.assert_in_headers("content-type: text/html")
 
     def test_assert_not_in_headers(self):
         response = http.get('http://blazedemo.com/')
@@ -88,7 +88,7 @@ class TestRequests(unittest.TestCase):
 
     def test_assert_regex_in_headers(self):
         response = http.get('http://blazedemo.com/')
-        response.assert_regex_in_headers(r"Content-Type: .+")
+        response.assert_regex_in_headers(r"content-type: .+")
 
     def test_assert_regex_not_in_headers(self):
         response = http.get('http://blazedemo.com/')

--- a/tests/test_body_data.py
+++ b/tests/test_body_data.py
@@ -4,10 +4,13 @@ from unittest import TestCase
 
 class TestRequests(TestCase):
     def test_body_string(self):
-        http.get('http://blazedemo.com/', data='MY PERFECT BODY')
+        http.post('http://blazedemo.com/', data='MY PERFECT BODY')
 
     def test_body_json(self):
-        http.get('http://blazedemo.com/', json={'foo': 'bar'})
+        http.post('http://blazedemo.com/', json={'foo': 'bar'})
+
+    def test_body_files(self):
+        http.post('http://blazedemo.com/', files=[('inp_file', ("filename", 'file-contents'))])
 
     def test_url_params(self):
         http.get('http://blazedemo.com/', params={'foo': 'bar'})

--- a/tests/test_methods.py
+++ b/tests/test_methods.py
@@ -4,30 +4,30 @@ from unittest import TestCase
 
 class TestHTTPMethods(TestCase):
     def test_get(self):
-        http.get('http://blazedemo.com/?tag=get')
+        http.get('https://blazedemo.com/?tag=get')
 
     def test_post(self):
-        http.post('http://blazedemo.com/?tag=post')
+        http.post('https://blazedemo.com/?tag=post')
 
     def test_put(self):
-        http.put('http://blazedemo.com/?tag=put')
+        http.put('https://blazedemo.com/?tag=put')
 
     def test_patch(self):
-        http.patch('http://blazedemo.com/?tag=patch')
+        http.patch('https://blazedemo.com/?tag=patch')
 
     def test_head(self):
-        http.head('http://blazedemo.com/?tag=head')
+        http.head('https://blazedemo.com/?tag=head')
 
     def test_delete(self):
-        http.delete('http://blazedemo.com/?tag=delete')
+        http.delete('https://blazedemo.com/?tag=delete')
 
     def test_options(self):
-        http.options('http://blazedemo.com/echo.php?echo=options')
+        http.options('https://blazedemo.com/echo.php?echo=options')
 
 
 class TestTargetMethods(TestCase):
     def setUp(self):
-        self.target = http.target('http://blazedemo.com', auto_assert_ok=False)
+        self.target = http.target('https://blazedemo.com', auto_assert_ok=False)
 
     def test_get(self):
         self.target.get('/echo.php?echo=get').assert_ok()

--- a/tests/test_samples.py
+++ b/tests/test_samples.py
@@ -111,11 +111,11 @@ class TestSamples(TestCase):
         self.assertEqual(1, len(first.subsamples))
         first_req = first.subsamples[0]
         self.assertEqual(first_req.test_suite, "blazedemo 123")
-        self.assertEqual(first_req.test_case, 'http://demo.blazemeter.com/echo.php?echo=123')
+        self.assertEqual(first_req.test_case, 'https://api.demoblaze.com/entries')
 
         self.assertEqual(second.test_suite, "test_requests")
         self.assertEqual(second.test_case, "blazedemo 456")
         self.assertEqual(1, len(second.subsamples))
         second_req = second.subsamples[0]
         self.assertEqual(second_req.test_suite, "blazedemo 456")
-        self.assertEqual(second_req.test_case, 'http://demo.blazemeter.com/echo.php?echo=456')
+        self.assertEqual(second_req.test_case, 'https://api.demoblaze.com/entries')

--- a/tests/test_samples.py
+++ b/tests/test_samples.py
@@ -14,7 +14,7 @@ class CachingWriter(object):
         self.samples = []
 
     def add(self, sample, test_count, success_count):
-        print(sample, test_count, success_count )
+        print(sample, test_count, success_count)
         self.samples.append(sample)
 
 
@@ -31,7 +31,7 @@ class TestSamples(TestCase):
         store.writer = CachingWriter()
         nose.run(argv=[__file__, test_file, '-v'], addplugins=[Recorder()])
         samples = store.writer.samples
-        self.assertEqual(len(samples), 6)
+        self.assertEqual(len(samples), 7)
 
         single = samples[0]
         self.assertEqual(single.test_suite, 'TestTransactions')
@@ -85,7 +85,14 @@ class TestSamples(TestCase):
         assertion = request.assertions[0]
         self.assertEqual(assertion.name, "assert_failed")
         self.assertEqual(assertion.failed, True)
-        self.assertEqual(assertion.error_message, "Request to http://blazedemo.com/ didn't fail (200)")
+        self.assertEqual(assertion.error_message, "Request to https://blazedemo.com/ didn't fail (200)")
+
+        assert_failed_req = samples[6]
+        self.assertEqual(assert_failed_req.status, "FAILED")
+        request = assert_failed_req.subsamples[0]
+        self.assertEqual(request.test_suite, "test_7_failed_request")
+        self.assertEqual(request.test_case, "http://notexists")
+        self.assertEqual(len(request.assertions), 0)
 
     def test_label_single_transaction(self):
         test_file = RESOURCES_DIR + "/test_single_transaction.py"

--- a/tests/test_transactions.py
+++ b/tests/test_transactions.py
@@ -4,7 +4,7 @@ import unittest
 
 from apiritif import http, transaction, transaction_logged
 
-target = http.target('https://jsonplaceholder.typicode.com')
+target = http.target('https://httpbin.org')
 target.keep_alive(True)
 target.auto_assert_ok(False)
 target.use_cookies(True)


### PR DESCRIPTION
+ add `files` parameter for http request. This parameter exists for `requests` lib, but is missing in Apiritif wrapper methods