### PR TITLE
Fix assertion trace for multi-asserts

### DIFF
--- a/apiritif/samples.py
+++ b/apiritif/samples.py
@@ -20,7 +20,6 @@ import traceback
 
 import apiritif
 from apiritif.http import RequestFailure
-from apiritif.utils import get_trace
 
 
 class Assertion(object):
@@ -91,9 +90,10 @@ class Sample(object):
         self.assertions.append(Assertion(name))
 
     def set_assertion_failed(self, name, error_message, error_trace=""):
-        for ass in self.assertions:
+        for ass in reversed(self.assertions):
             if ass.name == name:
                 ass.set_failed(error_message, error_trace)
+                break
         self.set_failed(error_message, error_trace)
 
     def to_dict(self):

--- a/tests/resources/test_transactions.py
+++ b/tests/resources/test_transactions.py
@@ -30,3 +30,9 @@ class TestTransactions(TestCase):
 
     def test_7_failed_request(self):
         apiritif.http.get("http://notexists")
+
+    def test_8_assertion_trace_problem(self):
+        resp = apiritif.http.get("http://blazedemo.com/")
+        resp.assert_regex_in_body(".*")
+        resp.assert_regex_in_body(".+")
+        resp.assert_regex_in_body("no way this exists in body")

--- a/tests/test_samples.py
+++ b/tests/test_samples.py
@@ -31,7 +31,7 @@ class TestSamples(TestCase):
         store.writer = CachingWriter()
         nose.run(argv=[__file__, test_file, '-v'], addplugins=[Recorder()])
         samples = store.writer.samples
-        self.assertEqual(len(samples), 7)
+        self.assertEqual(len(samples), 8)
 
         single = samples[0]
         self.assertEqual(single.test_suite, 'TestTransactions')
@@ -93,6 +93,16 @@ class TestSamples(TestCase):
         self.assertEqual(request.test_suite, "test_7_failed_request")
         self.assertEqual(request.test_case, "http://notexists")
         self.assertEqual(len(request.assertions), 0)
+
+        # checks if series of assertions is recorded into trace correctly
+        assert_seq_problem = samples[7]
+        self.assertEqual(assert_seq_problem.status, "FAILED")
+        request = assert_seq_problem.subsamples[0]
+        self.assertEqual(request.test_suite, "test_8_assertion_trace_problem")
+        self.assertEqual(len(request.assertions), 3)
+        self.assertFalse(request.assertions[0].failed)
+        self.assertFalse(request.assertions[1].failed)
+        self.assertTrue(request.assertions[2].failed)
 
     def test_label_single_transaction(self):
         test_file = RESOURCES_DIR + "/test_single_transaction.py"


### PR DESCRIPTION
Fixes the bug when failed assertion changes all similar assertion in the trace. Changed it to affect only very last one.