### PR TITLE
Write assertion params into trace extras

### DIFF
--- a/apiritif/__init__.py
+++ b/apiritif/__init__.py
@@ -17,6 +17,6 @@ from .csv import CSVReaderPerThread
 from .thread import put_into_thread_store, get_from_thread_store
 from .thread import get_transaction_handlers, set_transaction_handlers, get_iteration
 from .http import http, transaction, transaction_logged, smart_transaction, recorder
-from .http import TransactionStarted, TransactionEnded, Request, Assertion, AssertionFailure
+from .http import Event, TransactionStarted, TransactionEnded, Request, Assertion, AssertionFailure
 from .utilities import *
 from .utils import headers_as_text, assert_regexp, assert_not_regexp, log

--- a/apiritif/http.py
+++ b/apiritif/http.py
@@ -259,25 +259,27 @@ class smart_transaction(transaction_logged):
 
 
 class Event(object):
-    def __init__(self):
+    def __init__(self, response=None):
         self.timestamp = time.time()
+        self.response = response
+
+    def to_dict(self):  # supposed to be overridden by extenders
+        return {}
 
 
 class Request(Event):
     def __init__(self, method, address, request, response, session):
         """
-
         :type method: str
         :type address: str
         :type request: requests.PreparedRequest
         :type response: HTTPResponse
         :type session: requests.Session
         """
-        super(Request, self).__init__()
+        super(Request, self).__init__(response)
         self.method = method
         self.address = address
         self.request = request
-        self.response = response
         self.session = session
 
     def __repr__(self):
@@ -312,7 +314,7 @@ class RequestFailure(Request):
 
 class TransactionStarted(Event):
     def __init__(self, transaction):
-        super(TransactionStarted, self).__init__()
+        super(TransactionStarted, self).__init__(None)
         self.transaction = transaction
         self.transaction_name = transaction.name
 
@@ -332,9 +334,8 @@ class TransactionEnded(Event):
 
 class Assertion(Event):
     def __init__(self, name, response, extras):
-        super(Assertion, self).__init__()
+        super(Assertion, self).__init__(response)
         self.name = name
-        self.response = response
         self.extras = extras
 
     def __repr__(self):
@@ -343,9 +344,8 @@ class Assertion(Event):
 
 class AssertionFailure(Event):
     def __init__(self, assertion_name, response, failure_message):
-        super(AssertionFailure, self).__init__()
+        super(AssertionFailure, self).__init__(response)
         self.name = assertion_name
-        self.response = response
         self.failure_message = failure_message
 
     def __repr__(self):

--- a/apiritif/samples.py
+++ b/apiritif/samples.py
@@ -23,11 +23,12 @@ from apiritif.http import RequestFailure
 
 
 class Assertion(object):
-    def __init__(self, name, ):
+    def __init__(self, name, extras):
         self.name = name
         self.failed = False
         self.error_message = ""
         self.error_trace = ""
+        self.extras = extras
 
     def set_failed(self, error_message, error_trace=""):
         self.failed = True
@@ -86,8 +87,8 @@ class Sample(object):
         sample.set_parent(self)
         self.subsamples.append(sample)
 
-    def add_assertion(self, name):
-        self.assertions.append(Assertion(name))
+    def add_assertion(self, name, extras):
+        self.assertions.append(Assertion(name, extras))
 
     def set_assertion_failed(self, name, error_message, error_trace=""):
         for ass in reversed(self.assertions):
@@ -106,6 +107,8 @@ class Sample(object):
                 "name": ass.name,
                 "isFailed": ass.failed,
                 "errorMessage": ass.error_message,
+                "args": ass.extras['args'],
+                "kwargs": ass.extras['kwargs']
             })
 
         return {
@@ -222,7 +225,7 @@ class ApiritifSampleExtractor(object):
         sample = self.response_map.get(item.response, None)
         if sample is None:
             raise ValueError("Found assertion for unknown response")
-        sample.add_assertion(item.name)
+        sample.add_assertion(item.name, item.extras)
 
     def _parse_assertion_failure(self, item):
         sample = self.response_map.get(item.response, None)

--- a/apiritif/samples.py
+++ b/apiritif/samples.py
@@ -153,6 +153,8 @@ class ApiritifSampleExtractor(object):
                 self._parse_assertion(item)
             elif isinstance(item, apiritif.AssertionFailure):
                 self._parse_assertion_failure(item)
+            elif isinstance(item, apiritif.Event):
+                self._parse_generic_event(item)
             else:
                 raise ValueError("Unknown kind of event in apiritif recording: %s" % item)
 
@@ -232,6 +234,15 @@ class ApiritifSampleExtractor(object):
         if sample is None:
             raise ValueError("Found assertion failure for unknown response")
         sample.set_assertion_failed(item.name, item.failure_message, "")
+
+    def _parse_generic_event(self, item):
+        """
+        :type item: apiritif.Event
+        """
+        sample = self.response_map.get(item.response, None)
+        if sample is None:
+            raise ValueError("Generic event has to go after a request")
+        sample.extras.setdefault("additional_events", []).append(item.to_dict())
 
     @staticmethod
     def _headers_from_dict(headers):

--- a/apiritif/store.py
+++ b/apiritif/store.py
@@ -59,7 +59,7 @@ class SampleController(object):
 
     def addError(self, assertion_name, error_msg, error_trace, is_transaction=False):
         if self.tran_mode == is_transaction:
-            self.current_sample.add_assertion(assertion_name)
+            self.current_sample.add_assertion(assertion_name, {"args": [], "kwargs": {}})
             self.current_sample.set_assertion_failed(assertion_name, error_msg, error_trace)
 
     def addFailure(self, error, is_transaction=False):
@@ -67,7 +67,7 @@ class SampleController(object):
             assertion_name = error[0].__name__
             error_msg = str(error[1]).split('\n')[0]
             error_trace = get_trace(error)
-            self.current_sample.add_assertion(assertion_name)
+            self.current_sample.add_assertion(assertion_name, {"args": [], "kwargs": {}})
             self.current_sample.set_assertion_failed(assertion_name, error_msg, error_trace)
 
     def addSuccess(self, is_transaction=False):


### PR DESCRIPTION
The problem is: if you use multiple assertions of the same type, it is difficult to tell from the trace, which assertion you are looking at.

+ Allow to write custom tracing events into extras