### PR TITLE
Limit body part added to exception

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,4 +270,8 @@ debug http requests and write test interactively.
 
 TODO: describe how to silence Apiritif logging.
 
+### Environment Variables
 
+There are environment variables to control length of response/request body to be written into traces and logs:
+  * `APIRITIF_TRACE_BODY_EXCLIMIT` - limit of body part to include into exception messages, default is 1024
+  * `APIRITIF_TRACE_BODY_HARDLIMIT` - limit of body length to include into JSON trace records, default is unlimited

--- a/apiritif/http.py
+++ b/apiritif/http.py
@@ -16,6 +16,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 import copy
+import os
 import threading
 import time
 from functools import wraps
@@ -31,7 +32,7 @@ from apiritif.thread import get_from_thread_store, put_into_thread_store
 from apiritif.utilities import *
 from apiritif.utils import headers_as_text, assert_regexp, assert_not_regexp, log, get_trace
 
-BODY_LIMIT = 256
+BODY_LIMIT = int(os.environ.get("APIRITIF_TRACE_BODY_EXCLIMIT", "1024"))
 
 
 class TimeoutError(Exception):

--- a/apiritif/http.py
+++ b/apiritif/http.py
@@ -31,6 +31,8 @@ from apiritif.thread import get_from_thread_store, put_into_thread_store
 from apiritif.utilities import *
 from apiritif.utils import headers_as_text, assert_regexp, assert_not_regexp, log, get_trace
 
+BODY_LIMIT = 256
+
 
 class TimeoutError(Exception):
     pass
@@ -730,7 +732,7 @@ class HTTPResponse(object):
         body = self.json()
         matches = jsonpath_expr.find(body)
         if not matches:
-            msg = msg or "JSONPath query %r didn't match response content: %s" % (jsonpath_query, body)
+            msg = msg or "JSONPath query %r didn't match response: %s" % (jsonpath_query, self.text[:BODY_LIMIT])
             raise AssertionError(msg)
         actual_value = matches[0].value
         if expected_value is not None and actual_value != expected_value:
@@ -745,7 +747,7 @@ class HTTPResponse(object):
         body = self.json()
         matches = jsonpath_expr.find(body)
         if matches:
-            msg = msg or "JSONPath query %r did match response content: %s" % (jsonpath_query, body)
+            msg = msg or "JSONPath query %r did match response: %s" % (jsonpath_query, self.text[:BODY_LIMIT])
             raise AssertionError(msg)
         return self
 
@@ -755,7 +757,7 @@ class HTTPResponse(object):
         tree = etree.parse(BytesIO(self.content), parser)
         matches = tree.xpath(xpath_query)
         if not matches:
-            msg = msg or "XPath query %r didn't match response content: %s" % (xpath_query, self.text)
+            msg = msg or "XPath query %r didn't match response content: %s" % (xpath_query, self.text[:BODY_LIMIT])
             raise AssertionError(msg)
         return self
 
@@ -765,7 +767,7 @@ class HTTPResponse(object):
         tree = etree.parse(BytesIO(self.content), parser)
         matches = tree.xpath(xpath_query)
         if matches:
-            msg = msg or "XPath query %r did match response content: %s" % (xpath_query, self.text)
+            msg = msg or "XPath query %r did match response content: %s" % (xpath_query, self.text[:BODY_LIMIT])
             raise AssertionError(msg)
         return self
 
@@ -777,7 +779,7 @@ class HTTPResponse(object):
 
         matches = expected_value in vals if expected_value is not None else vals
         if not matches:
-            msg = msg or "CSSSelect query %r didn't match response content: %s" % (query, self.text)
+            msg = msg or "CSSSelect query %r didn't match response content: %s" % (query, self.text[:BODY_LIMIT])
             raise AssertionError(msg)
         return self
 
@@ -788,7 +790,7 @@ class HTTPResponse(object):
         except AssertionError:
             return self
 
-        msg = msg or "CSSSelect query %r did match response content: %s" % (query, self.text)
+        msg = msg or "CSSSelect query %r did match response content: %s" % (query, self.text[:BODY_LIMIT])
         raise AssertionError(msg)
 
     # TODO: assertTiming? to assert response time / connection time

--- a/apiritif/samples.py
+++ b/apiritif/samples.py
@@ -16,6 +16,7 @@ limitations under the License.
 """
 
 import copy
+import os
 import traceback
 
 import apiritif
@@ -284,8 +285,16 @@ class ApiritifSampleExtractor(object):
         req = request_event.request
         cookies = request_event.session.cookies
 
+        resp_text = resp.text
+        req_text = req.body or ""
+
+        hard_limit = int(os.environ.get("APIRITIF_TRACE_BODY_HARDLIMIT", "0"))
+        if hard_limit:
+            req_text = req_text[:hard_limit]
+            resp_text = resp_text[:hard_limit]
+
         return self._extras_dict(
             req.url, req.method, resp.status_code, resp.reason,
-            dict(resp.headers), resp.text, len(resp.content), resp.elapsed.total_seconds(),
-            req.body or "", cookies.get_dict(), dict(resp._request.headers)
+            dict(resp.headers), resp_text, len(resp.content), resp.elapsed.total_seconds(),
+            req_text, cookies.get_dict(), dict(resp._request.headers)
         )

--- a/apiritif/samples.py
+++ b/apiritif/samples.py
@@ -226,7 +226,7 @@ class ApiritifSampleExtractor(object):
     def _parse_assertion(self, item):
         sample = self.response_map.get(item.response, None)
         if sample is None:
-            raise ValueError("Found assertion for unknown response")
+            raise ValueError("Found assertion for unknown response: %r", item.response)
         sample.add_assertion(item.name, item.extras)
 
     def _parse_assertion_failure(self, item):


### PR DESCRIPTION
Because it leads to OOMs when we run a lot of tests with long bodies