### PR TITLE
Fix deprecated property usage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ matrix:
 
 install:
 - pip install .
-- pip install codecov nose nose-exclude nose-timer pluggy
+- pip install codecov nose nose-exclude nose-timer "pluggy>=1.0"
 script: coverage run -m nose --exclude-dir=tests/resources --with-timer
 after_success:
   - codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ matrix:
   - os: linux
     python: 3.9
 
-
 install:
 - pip install .
 - pip install codecov nose nose-exclude nose-timer "pluggy>=1.0"

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ matrix:
 
 
 install:
-- pip install .
+- pip install -U .
 - pip install codecov nose nose-exclude nose-timer
 script: coverage run -m nose --exclude-dir=tests/resources --with-timer
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: python
 dist: focal
+branches: # this prevents undesired branch builds for PRs
+  only:
+    - master
 
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,8 @@ matrix:
 
 
 install:
-- pip install -U .
-- pip install codecov nose nose-exclude nose-timer
+- pip install .
+- pip install codecov nose nose-exclude nose-timer pluggy
 script: coverage run -m nose --exclude-dir=tests/resources --with-timer
 after_success:
   - codecov

--- a/apiritif/pytest_plugin.py
+++ b/apiritif/pytest_plugin.py
@@ -47,7 +47,7 @@ class ApiritifPytestPlugin(object):
     def pytest_runtest_makereport(self, item, call):
         report = yield
         if call.when == 'call':
-            self._trace_map[item.nodeid] = self._get_subsamples(call, report.result, item)
+            self._trace_map[item.nodeid] = self._get_subsamples(call, report.get_result(), item)
 
     def _get_subsamples(self, call, report, item):
         recording = self._pop_events()

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
     docs_url='https://github.com/Blazemeter/apiritif',
 
     install_requires=[
-        'nose', 'pytest', 'requests>=2.24.0', 'jsonpath-ng', 'lxml',
+        'nose', 'pytest>=6.2.5', 'requests>=2.24.0', 'jsonpath-ng', 'lxml',
         'unicodecsv', 'cssselect', 'chardet', 'pyopenssl'
     ],
 

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
     docs_url='https://github.com/Blazemeter/apiritif',
 
     install_requires=[
-        'nose', 'pytest>=6.2.5', 'requests>=2.24.0', 'jsonpath-ng', 'lxml',
+        'nose', 'pytest>=6.2.5', 'pluggy>=1.0', 'requests>=2.24.0', 'jsonpath-ng', 'lxml',
         'unicodecsv', 'cssselect', 'chardet', 'pyopenssl'
     ],
 

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
     docs_url='https://github.com/Blazemeter/apiritif',
 
     install_requires=[
-        'nose', 'pytest>=6.2.5', 'pluggy>=1.0', 'requests>=2.24.0', 'jsonpath-ng', 'lxml',
+        'nose', 'pytest', 'requests>=2.24.0', 'jsonpath-ng', 'lxml',
         'unicodecsv', 'cssselect', 'chardet', 'pyopenssl'
     ],
 

--- a/tests/test_pytest_plugin.py
+++ b/tests/test_pytest_plugin.py
@@ -9,7 +9,7 @@ from _pytest.config.argparsing import Parser
 from _pytest.nodes import Node
 from _pytest.reports import TestReport
 from _pytest.runner import CallInfo
-from pluggy.callers import _Result
+from pluggy._result import _Result
 
 import apiritif
 from apiritif import http


### PR DESCRIPTION
Recently, there has been a major release of Pluggy, which has removed the `.result` property: https://github.com/pytest-dev/pluggy/commit/de2669fae04ba83b5206620e2a6518df145af7d0#

This breaks Apiritif after upgrade to pytest 6.2.5. 

This fix uses `get_result()` method, which exists for a while.