### PR TITLE
fix: remove codecov as a dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,3 @@ unicodecsv
 cssselect
 chardet
 pyopenssl
-codecov


### PR DESCRIPTION
Can we just remove this since https://about.codecov.io/blog/message-regarding-the-pypi-package/

Relates to issue https://github.com/Blazemeter/apiritif/issues/96

